### PR TITLE
extend Malli schema predicate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,25 @@ Transformer chain validation errors also return a special value:
 ;; => ::invalid-value
 ```
 
+All possible paths in the graph will be tested to resolve a result:
+```clojure
+(def multiple {:transformations {[:in :num] {:transformer #(Integer/parseInt %)}
+                                 [:in :str] {:transformer str}
+                                 [:str :out] {:transformer #(= "magic!" %)}
+                                 [:num :out] {:transformer #(= 6 %)}}})
+(def t3 (muotti/->transformer multiple))
+(muotti/transform t3 :in :out "6")
+;;=> true
+(muotti/transform t3 :in :out "magic!")
+;;=> true
+(muotti/transform t3 :in :out "0")
+;;=> false
+(muotti/transform t3 :in :out "anything")
+;;=> false
+```
+
+> Resolving order of paths is not guaranteed to be stable!
+
 ## [Malli](https://github.com/metosin/malli) integration
 
 Muotti is made to complement Malli's decoding and encoding capabilities through [Malli's Value Transformation](https://github.com/metosin/malli#value-transformation)
@@ -104,9 +123,9 @@ Use `:muotti/default` to provide a default value.
 
 ### Supported transformations
 
-The following transformations are pre-defined in the `muotti.malli/malli-config`.
-
-![Malli native types and supported transformations](./docs/images/muotti_malli_transformations.png)
+Muotti's aim is to support all major Malli types and predicates which are too numerous to list here. Instead see either
+ 1. [`muotti.malli-tests`](src/test/clj/muotti/malli_tests.clj) namespace or
+ 2. The DOT graph below
 
 ## [DOT/GraphViz](https://graphviz.org/) support
 
@@ -122,9 +141,4 @@ dot -Tpng /tmp/graph.dot > graph.png
 ```
 which results in
 
-![DOT example output](./docs/images/dot_example_output.png)
-
-## TODO
-
- - [ ] `:muotti/default` - allow Malli transformer to inject a default value for `nil` values
- - [ ] more comprehensive Malli schema registry support, currently just the basics are covered
+![DOT example output](./docs/images/graph.png)

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
 
                  ; all muotti extensions are optional
                  [borkdude/dynaload "0.2.2"]
-                 [metosin/malli "0.8.4" :scope "provided"]]
+                 [metosin/malli "0.8.9" :scope "provided"]]
 
   :deploy-repositories [["clojars" {:sign-releases false
                                     :url           "https://clojars.org/repo"
@@ -30,7 +30,8 @@
   :plugins [[fi.polycode/lein-git-revisions "1.0.0"]
             [lein-ancient "1.0.0-RC3"]
             [nvd-clojure "2.2.0"]
-            [lein-pprint "1.3.2"]]
+            [lein-pprint "1.3.2"]
+            [lein-kibit "0.1.8"]]
 
   :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]
   :global-vars {*warn-on-reflection* true}

--- a/src/dev/clj/muotti/dev.clj
+++ b/src/dev/clj/muotti/dev.clj
@@ -1,7 +1,7 @@
 (ns muotti.dev
   (:require [malli.core :as malli]
             [malli.transform :as mt]
-            [muotti.core :refer :all]
+            [muotti.core :as muotti]
             [muotti.malli :as mm]))
 
 (def adjacencies {[:keyword :string]  {:validator   keyword?

--- a/src/main/clj/muotti/malli.clj
+++ b/src/main/clj/muotti/malli.clj
@@ -1,9 +1,11 @@
 (ns muotti.malli
   (:require [malli.core :as malli]
+            [malli.registry :as mr]
             [malli.transform :as mt]
             [muotti.core :as muotti]
             [clojure.string :as str]
-            [clojure.tools.logging :as log]))
+            [clojure.tools.logging :as log])
+  (:import (clojure.lang BigInt Ratio)))
 
 ; Malli native types are :any, :nil, :string, :int, :double, :boolean, :keyword, :qualified-keyword, :symbol, :qualified-symbol, and :uuid
 ; Supporting :nil is kinda nonsensical, all others are somewhat doable
@@ -33,11 +35,64 @@
                                      [:qualified-symbol :any]     {:transformer identity}
                                      [:uuid :any]                 {:transformer identity}
 
-                                     ; malli.core/predicate-schemas
-                                     [:string pos?]               {:transformer parse-long}
-                                     [:int pos?]                  {:transformer identity}
-                                     [:double pos?]               {:transformer identity}}})
+                                     ; malli.core/predicate-schemas - extended types
+                                     [:string ::big-integer]      {:transformer (fn [^String s] (BigInteger. s))}
+                                     [:string ::ratio]            {:transformer (fn [^String s]
+                                                                                  (->> (clojure.string/split s #"/" 2)
+                                                                                       (mapv #(BigInteger. ^String %))
+                                                                                       (apply #(Ratio. %1 %2))))}
+                                     [:int ::big-integer]         {:transformer (fn [^String s] (BigInteger. s))}
+                                     [:int ::big-decimal]         {:transformer bigdec}
+                                     [:int ::float]               {:transformer float}
+                                     [:int ::ratio]               {:transformer #(Ratio.
+                                                                                   (. BigInteger (valueOf %))
+                                                                                   (. BigInteger (valueOf %)))}
+                                     ; malli.core/predicate-schemas - type test predicates
+                                     [:int 'int?]                 {:validator int? :transformer identity}
+                                     [:int 'integer?]             {:validator integer? :transformer identity}
+                                     [:int 'nat-int?]             {:validator nat-int? :transformer identity}
+                                     [:int 'number?]              {:validator number? :transformer identity}
 
+                                     [::big-integer 'integer?]    {:validator integer? :transformer identity}
+                                     [::big-integer 'nat-int?]    {:validator nat-int? :transformer identity}
+                                     [::big-integer 'number?]     {:validator number? :transformer identity}
+
+                                     [:double 'double?]           {:validator double? :transformer identity}
+                                     [:double 'float?]            {:validator float? :transformer identity}
+                                     [:double 'number?]           {:validator number? :transformer identity}
+
+                                     [::big-decimal 'decimal?]    {:validator decimal? :transformer identity}
+                                     [::big-decimal 'float?]      {:validator float? :transformer identity}
+                                     [::big-decimal 'number?]     {:validator number? :transformer identity}
+
+                                     [::float 'float?]            {:validator float? :transformer identity}
+                                     [::float 'number?]           {:validator number? :transformer identity}
+
+                                     [::ratio 'ratio?]            {:validator ratio? :transformer identity}
+                                     [::ratio 'number?]           {:validator number? :transformer identity}
+                                     ; malli.core/predicate-schemas - mathematical properties predicates
+                                     ['int? 'pos-int?]            {:validator pos-int? :transformer identity}
+                                     ['int? 'neg-int?]            {:validator neg-int? :transformer identity}
+
+                                     ['integer? 'rational?]       {:validator rational? :transformer identity}
+                                     ['ratio? 'rational?]         {:validator rational? :transformer identity}
+
+                                     ['number? 'pos?]             {:validator pos? :transformer identity}
+                                     ['number? 'neg?]             {:validator neg? :transformer identity}
+                                     ['number? 'zero?]            {:validator zero? :transformer identity}
+
+                                     ; unsupported due to ambiquity:
+                                     ;  any?, some?,
+                                     ; unsupported due to complex class relation:
+                                     ;  uuid?, uri?, inst?,
+                                     ; unsupported due to associative complexity:
+                                     ;  seqable?, indexed?, map?, vector?, list?, seq?,
+                                     ; maybe in the future:
+                                     ;  ident?, simple-ident?, qualified-ident?, keyword?, simple-keyword?,
+                                     ;  qualified-keyword?, symbol?, simple-symbol?, qualified-symbol?,
+                                     ;  char?, set?, nil?, false?, true?, zero?, rational?, coll?, empty?, associative?,
+                                     ;  sequential?, ratio?, bytes?, ifn? and fn?
+                                     }})
 (defn ^:private detect-type
   [_ v]
   (let [assumed-type (cond
@@ -71,18 +126,37 @@
           (do (log/infof "%s not supported: returning provided default %s" (log-context) default)
               default)
 
-          (not (some #{target-type} supported-types))
+          (not-any? #{target-type} supported-types)
           (do (log/warnf "%s not supported: unsupported target type, supported %s" (log-context) supported-types)
               x)
 
-          (and (keyword? (-> target-type))
-               (not= source-type target-type)
+          (and (not= source-type target-type)
                (and (not= ::unsupported source-type)
                     (not= ::unsupported target-type)))
           (do (log/infof "%s supported" (log-context))
               (muotti/transform transformer source-type target-type x))
 
-          :else x))))
+          :else
+          (do (log/errorf "%s unhandled: not sure what to do. %s" (log-context) {})
+              x)))))
+
+; thank you, random comment on Stackoverflow https://stackoverflow.com/a/12433266/44523
+(defn ^:private get-meta [o]
+  (->> *ns*
+       ns-map
+       (filter (fn [[_ v]] (and (var? v) (= o (var-get v)))))
+       first
+       second
+       meta))
+
+(defn ^:private symbolize
+  "Convert function names to symbols."
+  [maybe-fns]
+
+  (map (fn [v] (if (fn? v) (-> (get-meta v) :name) v)) maybe-fns))
+; TODO: Ei toimi, tsekkaa REPL-sessio
+; https://stackoverflow.com/a/12433266/44523
+; (symbol (name (quote pos?)))
 
 (defn ^:private ->malli-xformer
   [muotti-transformer from-fn to-fn]
@@ -92,7 +166,7 @@
       (partial from-fn schema)
       (partial to-fn schema)
       (malli/-properties schema)
-      (->> (muotti/config muotti-transformer) :transformations keys flatten set))))
+      (->> (muotti/config muotti-transformer) :transformations keys flatten symbolize set))))
 
 (defn transformer
   ([muotti-transformer]
@@ -103,3 +177,24 @@
        {:name            :muotti
         :default-decoder {:compile (->malli-xformer muotti-decoder detect-type from-schema)}
         :default-encoder {:compile (->malli-xformer muotti-encoder from-schema detect-type)}}))))
+
+;; XXX: similar to but not exactly as malli.core/-register-var
+(defn ^:private register-pred
+  [registry pred schema]
+  (assoc registry (-> pred meta :name) schema @pred schema))
+
+(defn extension-types-registry
+  [base-registry]
+  (let [instance?-schema (malli/-simple-schema
+                           (fn [opts _]
+                             {:type            (:muotti/type opts)
+                              :pred            #(instance? (:class opts) %)
+                              :type-properties {:error/fn (fn [error _] (str "Expected value to be " type ", was " (:value error) " instead"))}}))
+        custom-predicates (-> {}
+                              (register-pred #'instance? instance?-schema))]
+    (mr/composite-registry
+      base-registry
+      custom-predicates
+      {::big-int     (malli/schema [instance? {:muotti/type ::big-int :class BigInt}] {:registry custom-predicates})
+       ::big-integer (malli/schema [instance? {:muotti/type ::big-integer :class BigInteger}] {:registry custom-predicates})
+       ::big-decimal (malli/schema [instance? {:muotti/type ::big-decimal :class BigDecimal}] {:registry custom-predicates})})))

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -3,8 +3,9 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <withJansi>true</withJansi>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %yellow([%thread]) %highlight(%-5level) %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
This had been baking the whole summer, did some cleanup and finally pushed out to get muotti rolling again.

Turns out there's a _lot_ of potential predicates to support.

Fixes #2